### PR TITLE
Java 25

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -20,10 +20,10 @@ jobs:
           postgres
           postgres-test
 
-    - name: Set up JDK 21 for x64
+    - name: Set up JDK 25 for x64
       uses: actions/setup-java@v5
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'temurin'
         architecture: x64
 
@@ -87,10 +87,10 @@ jobs:
             --form file=@"$file"
           done
 
-      - name: Set up JDK 21 for x64
+      - name: Set up JDK 25 for x64
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           architecture: x64
 

--- a/.github/workflows/dockerhub-publish-quads-creator.yml
+++ b/.github/workflows/dockerhub-publish-quads-creator.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up JDK 21 for x64
+      - name: Set up JDK 25 for x64
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           architecture: x64
 

--- a/.github/workflows/dockerhub-publish-quads-delta.yml
+++ b/.github/workflows/dockerhub-publish-quads-delta.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up JDK 21 for x64
+      - name: Set up JDK 25 for x64
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           architecture: x64
 

--- a/.github/workflows/dockerhub-publish-quads-loader.yml
+++ b/.github/workflows/dockerhub-publish-quads-loader.yml
@@ -28,10 +28,10 @@ jobs:
             postgres
             postgres-test
 
-      - name: Set up JDK 21 for x64
+      - name: Set up JDK 25 for x64
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           architecture: x64
 

--- a/.github/workflows/dockerhub-publish-quads-query.yml
+++ b/.github/workflows/dockerhub-publish-quads-query.yml
@@ -42,10 +42,10 @@ jobs:
               --data-binary @"$file"
           done
 
-      - name: Set up JDK 21 for x64
+      - name: Set up JDK 25 for x64
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           architecture: x64
 

--- a/Readme.md
+++ b/Readme.md
@@ -62,18 +62,18 @@ Using a SQL as a backend for SPARQL has been done in some cases.
 
 ### Installation
 
-This project uses Java 21 JDK + Maven and
+This project uses Java 25 JDK + Maven and
 a [dockerized (make sure that Docker is installed too)](https://www.docker.com/) [PostgreSQL 17 database](https://www.postgresql.org/docs/17/index.html).
-If you don't have Java 21 installed by default, I recommend that you install [SDKMAN!](https://sdkman.io/) and use this
-tool to set Java 21 as current session version.
+If you don't have Java 25 installed by default, I recommend that you install [SDKMAN!](https://sdkman.io/) and use this
+tool to set Java 25 as current session version.
 
 > SDKMAN! is a tool for managing parallel versions of multiple Software Development Kits on most Unix based systems.
 
 Once you have `SDKMAN!` installed, run:
 
 ```shell
-sdk install java 21.0.1-amzn
-sdk use java 21.0.1-amzn
+sdk install java 25.0.3-tem
+sdk use java 25.0.3-tem
 ```
 
 Make sure you have Maven installed. If you don't have Maven installed, run: `sudo apt install maven`.

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>21</maven.compiler.source>
-    <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>25</maven.compiler.source>
+    <maven.compiler.target>25</maven.compiler.target>
   </properties>
 
   <modules>

--- a/quads-creator/Dockerfile
+++ b/quads-creator/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3-eclipse-temurin-21 AS build-create
+FROM maven:3-eclipse-temurin-25 AS build-create
 WORKDIR /app
 COPY . .
 RUN ["mvn", "package", "-Dmaven.test.skip=true"]
 
-FROM eclipse-temurin:21
+FROM eclipse-temurin:25
 
 LABEL maintainer="vcity, jey.puget-gil@liris.cnrs.fr"
 LABEL authors="jey.puget-gil@liris.cnrs.fr"

--- a/quads-creator/pom.xml
+++ b/quads-creator/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/quads-delta/Dockerfile
+++ b/quads-delta/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3-eclipse-temurin-21 AS build-create
+FROM maven:3-eclipse-temurin-25 AS build-create
 WORKDIR /app
 COPY . .
 RUN ["mvn", "package", "-Dmaven.test.skip=true"]
 
-FROM eclipse-temurin:21
+FROM eclipse-temurin:25
 
 LABEL maintainer="vcity, jey.puget-gil@liris.cnrs.fr"
 LABEL authors="jey.puget-gil@liris.cnrs.fr"

--- a/quads-delta/pom.xml
+++ b/quads-delta/pom.xml
@@ -8,8 +8,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/quads-loader-cli/Dockerfile
+++ b/quads-loader-cli/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3-eclipse-temurin-21 AS build-loader-cli
+FROM maven:3-eclipse-temurin-25 AS build-loader-cli
 WORKDIR /app
 COPY . .
 RUN ["mvn", "package", "-Dmaven.test.skip=true"]
 
-FROM eclipse-temurin:21
+FROM eclipse-temurin:25
 
 LABEL maintainer="vcity, jey.puget-gil@liris.cnrs.fr"
 LABEL authors="jey.puget-gil@liris.cnrs.fr"

--- a/quads-loader-cli/pom.xml
+++ b/quads-loader-cli/pom.xml
@@ -16,7 +16,8 @@
     <url>https://github.com/VCityTeam/ConVer-G</url>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
+        <lombok.version>1.18.46</lombok.version>
         <jacoco.version>0.8.14</jacoco.version>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
@@ -39,11 +40,13 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <version>42.7.11</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -89,6 +92,19 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/quads-loader/Dockerfile
+++ b/quads-loader/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3-eclipse-temurin-21 AS build-loader
+FROM maven:3-eclipse-temurin-25 AS build-loader
 WORKDIR /app
 COPY . .
 RUN ["mvn", "package", "-Dmaven.test.skip=true"]
 
-FROM eclipse-temurin:21
+FROM eclipse-temurin:25
 
 LABEL maintainer="vcity, jey.puget-gil@liris.cnrs.fr"
 LABEL authors="jey.puget-gil@liris.cnrs.fr"

--- a/quads-loader/pom.xml
+++ b/quads-loader/pom.xml
@@ -16,7 +16,8 @@
     <url>https://github.com/VCityTeam/ConVer-G</url>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
+        <lombok.version>1.18.46</lombok.version>
         <jmh.version>1.36</jmh.version>
         <jacoco.version>0.8.14</jacoco.version>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
@@ -27,6 +28,17 @@
         <sonar.language>java</sonar.language>
         <prometheus.project.version>1.3.2</prometheus.project.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.zonky.test.postgres</groupId>
+                <artifactId>embedded-postgres-binaries-bom</artifactId>
+                <version>18.3.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -45,16 +57,24 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <version>42.7.11</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <version>2.2.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -107,6 +127,19 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>

--- a/quads-loader/src/main/resources/schema.sql
+++ b/quads-loader/src/main/resources/schema.sql
@@ -2,6 +2,8 @@ DROP TRIGGER IF EXISTS trg_insert_metadata_vng ON versioned_named_graph^;
 DROP FUNCTION IF EXISTS trg_fn_insert_metadata_vng^;
 DROP FUNCTION IF EXISTS version_named_graph(varchar, varchar, integer)^;
 
+CREATE EXTENSION IF NOT EXISTS pgcrypto^;
+
 CREATE TABLE IF NOT EXISTS resource_or_literal
 (
     id_resource_or_literal integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY,

--- a/quads-loader/src/test/java/fr/vcity/converg/controllers/EmbeddedPostgresTestSupport.java
+++ b/quads-loader/src/test/java/fr/vcity/converg/controllers/EmbeddedPostgresTestSupport.java
@@ -1,0 +1,38 @@
+package fr.vcity.converg.controllers;
+
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+
+abstract class EmbeddedPostgresTestSupport {
+
+    private static final int POSTGRES_PORT = 5433;
+
+    private static final EmbeddedPostgres EMBEDDED_POSTGRES = startEmbeddedPostgres();
+
+    @BeforeAll
+    static void initializeEmbeddedDatabase() {
+        // The static initializer starts the database before Spring creates the context.
+    }
+
+    @DynamicPropertySource
+    static void registerDataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", () -> "jdbc:postgresql://localhost:" + POSTGRES_PORT + "/postgres");
+        registry.add("spring.datasource.username", () -> "postgres");
+        registry.add("spring.datasource.password", () -> "postgres");
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    }
+
+    private static EmbeddedPostgres startEmbeddedPostgres() {
+        try {
+            return EmbeddedPostgres.builder()
+                    .setPort(POSTGRES_PORT)
+                    .start();
+        } catch (IOException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+}

--- a/quads-loader/src/test/java/fr/vcity/converg/controllers/QuadImportControllerTest.java
+++ b/quads-loader/src/test/java/fr/vcity/converg/controllers/QuadImportControllerTest.java
@@ -7,7 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-class QuadImportControllerTest {
+class QuadImportControllerTest extends EmbeddedPostgresTestSupport {
 
     @Autowired
     QuadImportController quadImportController;

--- a/quads-loader/src/test/java/fr/vcity/converg/controllers/QuadsImporterHttpRequestTests.java
+++ b/quads-loader/src/test/java/fr/vcity/converg/controllers/QuadsImporterHttpRequestTests.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class QuadsImporterHttpRequestTests {
+class QuadsImporterHttpRequestTests extends EmbeddedPostgresTestSupport {
 
     @LocalServerPort
     private int port;

--- a/quads-loader/src/test/resources/application.properties
+++ b/quads-loader/src/test/resources/application.properties
@@ -1,7 +1,7 @@
-spring.datasource.url=jdbc:postgresql://localhost:5433/converg-test
+spring.datasource.url=jdbc:postgresql://localhost:5433/postgres
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=postgres-test
-spring.datasource.password=password-test
+spring.datasource.username=postgres
+spring.datasource.password=postgres
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=none
 spring.sql.init.mode=always

--- a/quads-query-cli/Dockerfile
+++ b/quads-query-cli/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3-eclipse-temurin-21 AS build-query-cli
+FROM maven:3-eclipse-temurin-25 AS build-query-cli
 WORKDIR /app
 COPY . .
 RUN ["mvn", "package", "-Dmaven.test.skip=true"]
 
-FROM eclipse-temurin:21
+FROM eclipse-temurin:25
 
 LABEL maintainer="vcity, jey.puget-gil@liris.cnrs.fr"
 LABEL authors="jey.puget-gil@liris.cnrs.fr"

--- a/quads-query-cli/pom.xml
+++ b/quads-query-cli/pom.xml
@@ -13,8 +13,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -51,20 +51,20 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.18.2</version>
+            <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.2</version>
+            <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
         <!-- db access -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.4</version>
+            <version>42.7.11</version>
         </dependency>
 
         <!--  Google guava  -->

--- a/quads-query/Dockerfile
+++ b/quads-query/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3-eclipse-temurin-21 AS build-query
+FROM maven:3-eclipse-temurin-25 AS build-query
 WORKDIR /app
 COPY . .
 RUN ["mvn", "package", "-Dmaven.test.skip=true"]
 
-FROM eclipse-temurin:21
+FROM eclipse-temurin:25
 
 LABEL maintainer="vcity, jey.puget-gil@liris.cnrs.fr"
 LABEL authors="jey.puget-gil@liris.cnrs.fr"

--- a/quads-query/pom.xml
+++ b/quads-query/pom.xml
@@ -13,8 +13,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <prometheus.project.version>1.3.2</prometheus.project.version>
     </properties>
 


### PR DESCRIPTION
- Upgraded project/runtime pins to Java 25 across Maven, CI, Docker, and docs.
- Added explicit Lombok processing for the loader modules.
- Fixed CVE-reported PostgreSQL and Jackson dependencies.
- Switched loader integration tests to embedded PostgreSQL on port 5433.
- Security: upgraded pgjdbc and jackson-databind to patched releases.